### PR TITLE
For every function with optional args, use a struct instead of map[string]interface{}

### DIFF
--- a/bamboohr.go
+++ b/bamboohr.go
@@ -13,26 +13,33 @@ type Client struct {
 	HTTPClient  *http.Client
 }
 
+// BBHRNewInput is used as input to the New() function
+type BBHRNewInput struct {
+	Version string
+	Company string
+	APIKey  string
+}
+
 // New creates a new BambooHR API Client and returns it to the caller
-func New(args map[string]interface{}) (*Client, error) {
+func New(args BBHRNewInput) (*Client, error) {
 	newClient := &Client{}
 
-	if _, ok := args["version"]; !ok {
-		args["version"] = "v1"
+	// Default version to v1
+	if args.Version == "" {
+		args.Version = "v1"
 	}
 
-	if _, ok := args["company"]; !ok {
-		return newClient, fmt.Errorf("missing arg: company")
+	if args.Company == "" {
+		return newClient, fmt.Errorf("missing arg: Company")
 	}
 
-	if _, ok := args["apikey"]; !ok {
-		return newClient, fmt.Errorf("missing arg: apikey")
+	if args.APIKey == "" {
+		return newClient, fmt.Errorf("missing arg: APIKey")
 	} else {
-		newClient.APIKey = args["apikey"].(string)
+		newClient.APIKey = args.APIKey
 	}
 
-	newClient.APIEndpoint = fmt.Sprintf("https://api.bamboohr.com/api/gateway.php/%s/%s", args["company"], args["version"])
-
+	newClient.APIEndpoint = fmt.Sprintf("https://api.bamboohr.com/api/gateway.php/%s/%s", args.Company, args.Version)
 	newClient.HTTPClient = http.DefaultClient
 
 	return newClient, nil

--- a/employeeFiles.go
+++ b/employeeFiles.go
@@ -5,27 +5,15 @@ import (
 )
 
 // ListFilesByEmployee will list all the files a given employee has in their account
-func (b *Client) ListFilesByEmployee(args map[string]interface{}) ([]byte, error) {
-	if _, ok := args["employeeid"]; !ok {
-		return []byte{}, fmt.Errorf("missing field: employeeid")
-	}
-
-	endpointURL := fmt.Sprintf("%s/%s/%s/files/view", b.APIEndpoint, "employees", args["employeeid"])
+func (b *Client) ListFilesByEmployee(id string) ([]byte, error) {
+	endpointURL := fmt.Sprintf("%s/employees/%s/files/view", b.APIEndpoint, id)
 
 	return b.getRequest(endpointURL)
 }
 
 // GetFileFromEmployee will get a specified file from an employee
-func (b *Client) GetFileFromEmployee(args map[string]interface{}) ([]byte, error) {
-	if _, ok := args["employeeid"]; !ok {
-		return []byte{}, fmt.Errorf("missing field: employeeid")
-	}
-
-	if _, ok := args["fileid"]; !ok {
-		return []byte{}, fmt.Errorf("missing field: fileid")
-	}
-
-	endpointURL := fmt.Sprintf("%s/%s/%s/files/%s", b.APIEndpoint, "employees", args["employeeid"], args["fileid"])
+func (b *Client) GetFileFromEmployee(empID, fileID string) ([]byte, error) {
+	endpointURL := fmt.Sprintf("%s/employees/%s/files/%s", b.APIEndpoint, empID, fileID)
 
 	return b.getRequest(endpointURL)
 }

--- a/employees.go
+++ b/employees.go
@@ -11,16 +11,22 @@ func (b *Client) ListEmployees() ([]byte, error) {
 	return b.getRequest(endpointURL)
 }
 
+// BBHRGetEmployeeInput is used as an input struct for the GetEmployee function
+type BBHRGetEmployeeInput struct {
+	EmployeeID string
+	Fields     string
+}
+
 // GetEmployee gets a specific employee
-func (b *Client) GetEmployee(args map[string]interface{}) ([]byte, error) {
-	if _, ok := args["employeeid"]; !ok {
-		return []byte{}, fmt.Errorf("missing field: employeeid")
+func (b *Client) GetEmployee(args BBHRGetEmployeeInput) ([]byte, error) {
+	if args.EmployeeID == "" {
+		return []byte{}, fmt.Errorf("missing field: EmployeeID")
 	}
-	if _, ok := args["fields"]; !ok {
-		args["fields"] = "firstName,lastName"
+	if args.Fields == "" {
+		args.Fields = "firstName,lastName"
 	}
 
-	endpointURL := fmt.Sprintf("%s/%s/%s/?fields=%s", b.APIEndpoint, "employees", args["employeeid"], args["fields"])
+	endpointURL := fmt.Sprintf("%s/employees/%s/?fields=%s", b.APIEndpoint, args.EmployeeID, args.Fields)
 
 	return b.getRequest(endpointURL)
 }

--- a/goals.go
+++ b/goals.go
@@ -23,16 +23,27 @@ func (b *Client) ListGoalsForEmployee(id string) ([]byte, error) {
 	return b.getRequest(endpointURL)
 }
 
-// ListAvailableGoalSharingOptions lists the employees with whom the specified employees goals can be shared
-func (b *Client) ListAvailableGoalSharingOptions(id string, args map[string]string) ([]byte, error) {
-	endpointURL := fmt.Sprintf("%s/performance/employees/%s/goals/sharedOptions", b.APIEndpoint, id)
+// BBHRListAvailableGoalSharingOptionsInput is used as input for the ListAvailableGoalSharingOptions function
+type BBHRListAvailableGoalSharingOptionsInput struct {
+	EmployeeID string
+	Search     string
+	Limit      string
+}
 
-	if searchOptions, ok := args["search"]; ok {
-		endpointURL += fmt.Sprintf("&search=%s", searchOptions)
+// ListAvailableGoalSharingOptions lists the employees with whom the specified employees goals can be shared
+func (b *Client) ListAvailableGoalSharingOptions(args BBHRListAvailableGoalSharingOptionsInput) ([]byte, error) {
+	if args.EmployeeID == "" {
+		return []byte{}, fmt.Errorf("missing arg: EmployeeID")
 	}
 
-	if limit, ok := args["limit"]; ok {
-		endpointURL += fmt.Sprintf("&limit=%s", limit)
+	endpointURL := fmt.Sprintf("%s/performance/employees/%s/goals/sharedOptions", b.APIEndpoint, args.EmployeeID)
+
+	if args.Search != "" {
+		endpointURL += fmt.Sprintf("&search=%s", args.Search)
+	}
+
+	if args.Limit != "" {
+		endpointURL += fmt.Sprintf("&limit=%s", args.Limit)
 	}
 
 	return b.getRequest(endpointURL)

--- a/reports.go
+++ b/reports.go
@@ -4,19 +4,26 @@ import (
 	"fmt"
 )
 
+// BBHRGetCompanayReportInput is used as input for the GetCompanyReport function
+type BBHRGetCompanyReportInput struct {
+	ReportID string
+	Format   string
+	FD       string
+}
+
 // GetCompanyReport gets a company report
-func (b *Client) GetCompanyReport(args map[string]string) ([]byte, error) {
-	if _, ok := args["id"]; !ok {
-		return []byte{}, fmt.Errorf("missing arg: id")
+func (b *Client) GetCompanyReport(args BBHRGetCompanyReportInput) ([]byte, error) {
+	if args.ReportID == "" {
+		return []byte{}, fmt.Errorf("missing arg: ReportID")
 	}
 
-	endpointURL := fmt.Sprintf("%s/reports/%s", b.APIEndpoint, args["id"])
+	endpointURL := fmt.Sprintf("%s/reports/%s", b.APIEndpoint, args.ReportID)
 
-	if _, ok := args["format"]; !ok {
-		return []byte{}, fmt.Errorf("missing arg: format")
+	if args.Format == "" {
+		return []byte{}, fmt.Errorf("missing arg: Format")
 	}
 
-	switch args["format"] {
+	switch args.Format {
 	case "csv":
 	case "pdf":
 	case "xls":
@@ -26,10 +33,10 @@ func (b *Client) GetCompanyReport(args map[string]string) ([]byte, error) {
 		return []byte{}, fmt.Errorf("arg 'format' must be one of: csv, pdf, xls, xml, json")
 	}
 
-	endpointURL += fmt.Sprintf("&format=%s", args["format"])
+	endpointURL += fmt.Sprintf("&format=%s", args.Format)
 
-	if _, ok := args["fd"]; ok {
-		endpointURL += fmt.Sprintf("&fd=%s", args["fd"])
+	if args.FD != "" {
+		endpointURL += fmt.Sprintf("&fd=%s", args.FD)
 	}
 
 	return b.getRequest(endpointURL)

--- a/timeoff.go
+++ b/timeoff.go
@@ -23,28 +23,41 @@ func (b *Client) ListTimeOffPolicies() ([]byte, error) {
 	return b.getRequest(endpointURL)
 }
 
+// BBHRListTimeOffRequestsInput is used as input for the ListTimeOffRequests function
+type BBHRListTimeOffRequestsInput struct {
+	Start time.Time
+	End   time.Time
+
+	TimeOffID  string
+	EmployeeID string
+
+	Action string
+	Status string
+	Type   string
+}
+
 // ListTimeOffRequests lists the timeoff requests
-func (b *Client) ListTimeOffRequests(start, end time.Time, args map[string]interface{}) ([]byte, error) {
-	endpointURL := fmt.Sprintf("%s/time_off/requests/?start=%s&end=%s", b.APIEndpoint, start.Format("2006-01-02"), end.Format("2006-01-02"))
+func (b *Client) ListTimeOffRequests(args BBHRListTimeOffRequestsInput) ([]byte, error) {
+	endpointURL := fmt.Sprintf("%s/time_off/requests/?start=%s&end=%s", b.APIEndpoint, args.Start.Format("2006-01-02"), args.End.Format("2006-01-02"))
 
-	if id, ok := args["id"]; ok {
-		endpointURL += fmt.Sprintf("&id=%s", id)
+	if args.TimeOffID != "" {
+		endpointURL += fmt.Sprintf("&id=%s", args.TimeOffID)
 	}
 
-	if action, ok := args["action"]; ok {
-		endpointURL += fmt.Sprintf("&action=%s", action)
+	if args.Action != "" {
+		endpointURL += fmt.Sprintf("&action=%s", args.Action)
 	}
 
-	if empId, ok := args["employeeid"]; ok {
-		endpointURL += fmt.Sprintf("&employeeId=%s", empId)
+	if args.EmployeeID != "" {
+		endpointURL += fmt.Sprintf("&employeeId=%s", args.EmployeeID)
 	}
 
-	if tType, ok := args["type"]; ok {
-		endpointURL += fmt.Sprintf("&type=%s", tType)
+	if args.Type != "" {
+		endpointURL += fmt.Sprintf("&type=%s", args.Type)
 	}
 
-	if status, ok := args["status"]; ok {
-		endpointURL += fmt.Sprintf("&status=%s", status)
+	if args.Status != "" {
+		endpointURL += fmt.Sprintf("&status=%s", args.Status)
 	}
 
 	return b.getRequest(endpointURL)


### PR DESCRIPTION
This PR modifies all functions that were using a `map[string]interface{}` as an input argument.

All functions that had only required args were changed to use normal function arguments, and all functions that had some optional arguments now use an input struct specific for that function.

Closes: #4